### PR TITLE
Add EOL and new app-id

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-  "end-of-life": "This application is no longer maintained because it is being phased out in favor of the new Skiff app."
+  "end-of-life": "This application is no longer maintained because it is being phased out in favor of the new Skiff app.",
   "end-of-life-rebase": "com.fyralabs.SkiffDesktop"
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "This application is no longer maintained because it is being phased out in favor of the new Skiff app."
+  "end-of-life-rebase": "com.fyralabs.SkiffDesktop"
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-  "end-of-life": "This application is no longer maintained because it is being phased out in favor of the new Skiff app.",
+  "end-of-life": "This application is no longer maintained because it is being phased out in favor of com.fyralabs.SkiffDesktop",
   "end-of-life-rebase": "com.fyralabs.SkiffDesktop"
 }

--- a/io.github.dhadder3.SkiffDesktopAdw.json
+++ b/io.github.dhadder3.SkiffDesktopAdw.json
@@ -38,7 +38,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/dhadder3/skiffdesktop-adw.git",
-                    "tag" : "0.1.2",
+                    "tag" : "0.1.3",
                     "commit" : "c1afaf92cffd0e7f594de4ada5b199f3f1fa480f"
                 }
             ],

--- a/io.github.dhadder3.SkiffDesktopAdw.json
+++ b/io.github.dhadder3.SkiffDesktopAdw.json
@@ -39,7 +39,7 @@
                     "type" : "git",
                     "url" : "https://github.com/dhadder3/skiffdesktop-adw.git",
                     "tag" : "0.1.3",
-                    "commit" : "c1afaf92cffd0e7f594de4ada5b199f3f1fa480f"
+                    "commit" : "71027a10a925cf283fcddae3bbb718914dd797f2"
                 }
             ],
             "modules" : [


### PR DESCRIPTION
This app is no longer receiving updates at this time as it has been decided to keep only one Skiff app on Flathub. The new app-id has been added to the flathub.json file with an end of life message.